### PR TITLE
Solved Missing Lua Library in Ubuntu 18.04

### DIFF
--- a/lua53.pas
+++ b/lua53.pas
@@ -103,7 +103,7 @@ const
 {$IFDEF MSWINDOWS}
    LUA_LIB_NAME = 'lua53.dll';
 {$ELSE}
-   LUA_LIB_NAME = 'liblua53.so';
+   LUA_LIB_NAME = 'liblua5.3.so';
 {$ENDIF}
 
 const


### PR DESCRIPTION
Problem: lua53.pas couldn't find liblua5.3-dev in my System...
Simple solution really. Probably also affects Mac OS X, as it also put a dot between 5 and 3 in the liblua5.3.so library when installed with Homebrew, Discrepancy identified when I ran the command 
```
$ ldconfig -p | grep liblua
```